### PR TITLE
nitro 2.7.dev6

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,34 @@
+:: cmd
+echo "Building %PKG_NAME%."
+
 mkdir build
 cd build
+if errorlevel 1 exit /b 1
 
 set CXXFLAGS="/D_HAS_AUTO_PTR_ETC=1"
 
-cmake -G "NMake Makefiles" ^
+:: Generate the build files.
+echo "Generating the build files..."
+cmake .. %CMAKE_ARGS% ^
+      -G"Ninja" ^
       -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE:STRING=Release ^
 	-DBUILD_SHARED_LIBS=ON ^
       %SRC_DIR%
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 1
 
-nmake
-if errorlevel 1 exit 1
+:: Build.
+echo "Building..."
+ninja -j%CPU_COUNT%
+if errorlevel 1 exit /b 1
 
 
-nmake install
-if errorlevel 1 exit 1
+:: Install.
+echo "Installing..."
+ninja install
+if errorlevel 1 exit /b 1
+
+
+:: Error free exit.
+echo "Error free exit!"
+exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,7 +6,7 @@ set CXXFLAGS="/D_HAS_AUTO_PTR_ETC=1"
 cmake -G "NMake Makefiles" ^
       -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE:STRING=Release ^
-	  -DBUILD_SHARED_LIBS=ON ^
+	-DBUILD_SHARED_LIBS=ON ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 
@@ -16,5 +16,3 @@ if errorlevel 1 exit 1
 
 nmake install
 if errorlevel 1 exit 1
-
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-set -e
-set -x
+
+set -ex
+
 mkdir build
 cd build
+
 cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX ${SRC_DIR}
+
 make -j${CPU_COUNT}
+
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,22 @@
 {% set name = "nitro" %}
 {% set version = "2.7.dev6" %}
-{% set sha256 = "c3a514c9773f9ffd981e48fd5c4da2797118245b8d1a0e526553c363883450ca" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ version }}.tar.gz
   url: https://github.com/hobu/{{ name }}/archive/2.7dev-6.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c3a514c9773f9ffd981e48fd5c4da2797118245b8d1a0e526553c363883450ca
 
 build:
   skip: True  # [win and vc<14]
-  number: 5
+  number: 0
 
 requirements:
   build:
     - cmake
-    - make
+    - make  # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -35,9 +33,13 @@ test:
 
 about:
   home: https://github.com/hobu/nitro
-  summary: "A GIT Mirror of Nitro NITF project"
+  summary: A GIT Mirror of Nitro NITF project
+  description: A GIT Mirror of Nitro NITF project
   license: LGPL-3.0-or-later
+  license_family: LGPL
   license_file: COPYING
+  dev_url: https://github.com/hobu/nitro
+  doc_url: https://github.com/hobu/nitro
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
 requirements:
   build:
     - cmake
-    - make  # [not win]
+    - make   # [not win]
+    - ninja  # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:


### PR DESCRIPTION
pdal requires nitro

Changelog: https://github.com/hobu/nitro/blob/2.7dev-6/CHANGES
License: https://github.com/hobu/nitro/blob/2.7dev-6/COPYING
Requirements:
- https://github.com/hobu/nitro/blob/2.7dev-6/CMakeLists.txt

Actions:
1. Remove empty lines and fix indentation
2. Use `make` on `unix` only
3. Add description
4. Add license_family
5. Add dev & doc urls